### PR TITLE
image now usable in Bitbucket pipelines (curl added to Dockerfile)

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -13,7 +13,7 @@ RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula selec
     apt-get -y dist-upgrade && \
 
     apt-get install -qy --no-install-recommends \
-      make unzip ttf-mscorefonts-installer \
+      make unzip curl ttf-mscorefonts-installer \
       latexmk biber python-pygments gnuplot cm-super \
       texlive-xetex texlive-generic-extra texlive-fonts-recommended lmodern fonts-liberation texlive-bibtex-extra \
       texlive-lang-cyrillic texlive-latex-extra texlive-science texlive-pstricks && \


### PR DESCRIPTION
BitBucket allows using Docker to build sources, but needs curl to obtain artifacts. Adding curl to this container may be of great benefit to the ones using Bitbucket as their LaTeX files storage. Please, consider this possibility. 